### PR TITLE
RCAL-704: Updates needed for resample running

### DIFF
--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -61,7 +61,7 @@ class MosaicModel(_RomanDataModel):
             Metadata from a component image of the mosiac.
         """
 
-        # Convert input to a dictionary, if neccesary
+        # Convert input to a dictionary, if necessary
         if not isinstance(meta, dict):
             meta_dict = meta.to_flat_dict()
         else:
@@ -74,7 +74,7 @@ class MosaicModel(_RomanDataModel):
         # Sift through meta items to place in tables
         for key, value in meta_dict.items():
             # Skip wcs objects
-            if (key == 'wcs'):
+            if key == "wcs":
                 continue
 
             # Keys that are themselves Dnodes (subdirectories)

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -42,10 +42,7 @@ class _RomanDataModel(_DataModel):
         super().__init__(init, **kwargs)
 
         if init is not None:
-            if self._node_type == stnode.WfiMosaic:
-                self.meta.basic.model_type = self.__class__.__name__
-            else:
-                self.meta.model_type = self.__class__.__name__
+            self.meta.model_type = self.__class__.__name__
 
 
 class MosaicModel(_RomanDataModel):

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -676,7 +676,6 @@ def mk_mosaic_basic(**kwargs):
     mosbasic["location_name"] = kwargs.get("location_name", NOSTR)
     mosbasic["product_type"] = kwargs.get("product_type", NOSTR)
 
-
     return mosbasic
 
 
@@ -730,7 +729,7 @@ def mk_individual_image_meta(**kwargs):
 
     imm = stnode.IndividualImageMeta()
 
-    table_dct = {"dummy":[NONUM]}
+    table_dct = {"dummy": [NONUM]}
 
     imm["basic"] = kwargs.get("basic", QTable(table_dct))
     imm["aperture"] = kwargs.get("aperture", QTable(table_dct))

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -415,7 +415,6 @@ def mk_common_meta(**kwargs):
     meta["velocity_aberration"] = mk_velocity_aberration(**kwargs.get("velocity_aberration", {}))
     meta["visit"] = mk_visit(**kwargs.get("visit", {}))
     meta["wcsinfo"] = mk_wcsinfo(**kwargs.get("wcsinfo", {}))
-    meta["wcs"] = kwargs.get("wcs", None)
 
     return meta
 
@@ -451,7 +450,6 @@ def mk_mosaic_meta(**kwargs):
     meta["program"] = mk_program(**kwargs.get("program", {}))
     meta["resample"] = mk_resample(**kwargs.get("resample", {}))
     meta["wcsinfo"] = mk_mosaic_wcsinfo(**kwargs.get("wcsinfo", {}))
-    meta["wcs"] = kwargs.get("wcs", None)
 
     return meta
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -415,7 +415,7 @@ def mk_common_meta(**kwargs):
     meta["velocity_aberration"] = mk_velocity_aberration(**kwargs.get("velocity_aberration", {}))
     meta["visit"] = mk_visit(**kwargs.get("visit", {}))
     meta["wcsinfo"] = mk_wcsinfo(**kwargs.get("wcsinfo", {}))
-    meta["wcs"] = None
+    meta["wcs"] = kwargs.get("wcs", None)
 
     return meta
 
@@ -451,7 +451,7 @@ def mk_mosaic_meta(**kwargs):
     meta["program"] = mk_program(**kwargs.get("program", {}))
     meta["resample"] = mk_resample(**kwargs.get("resample", {}))
     meta["wcsinfo"] = mk_mosaic_wcsinfo(**kwargs.get("wcsinfo", {}))
-    meta["wcs"] = None
+    meta["wcs"] = kwargs.get("wcs", None)
 
     return meta
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -415,6 +415,7 @@ def mk_common_meta(**kwargs):
     meta["velocity_aberration"] = mk_velocity_aberration(**kwargs.get("velocity_aberration", {}))
     meta["visit"] = mk_visit(**kwargs.get("visit", {}))
     meta["wcsinfo"] = mk_wcsinfo(**kwargs.get("wcsinfo", {}))
+    meta["wcs"] = None
 
     return meta
 
@@ -444,13 +445,13 @@ def mk_mosaic_meta(**kwargs):
     dict (defined by the wfi_mosaic-1.0.0 schema)
     """
 
-    meta = {}
-    meta["filename"] = None
+    meta = mk_basic_meta(**kwargs)
     meta["basic"] = mk_mosaic_basic(**kwargs.get("basic", {}))
     meta["individual_image_meta"] = mk_individual_image_meta(**kwargs.get("individual_image_meta", {}))
     meta["program"] = mk_program(**kwargs.get("program", {}))
     meta["resample"] = mk_resample(**kwargs.get("resample", {}))
     meta["wcsinfo"] = mk_mosaic_wcsinfo(**kwargs.get("wcsinfo", {}))
+    meta["wcs"] = None
 
     return meta
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -445,6 +445,7 @@ def mk_mosaic_meta(**kwargs):
     """
 
     meta = {}
+    meta["filename"] = None
     meta["basic"] = mk_mosaic_basic(**kwargs.get("basic", {}))
     meta["individual_image_meta"] = mk_individual_image_meta(**kwargs.get("individual_image_meta", {}))
     meta["program"] = mk_program(**kwargs.get("program", {}))

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -666,7 +666,6 @@ def mk_mosaic_basic(**kwargs):
     mosbasic["time_mean_mjd"] = kwargs.get("time_mean_mjd", NONUM)
     mosbasic["max_exposure_time"] = kwargs.get("max_exposure_time", NONUM)
     mosbasic["mean_exposure_time"] = kwargs.get("mean_exposure_time", NONUM)
-    mosbasic["model_type"] = kwargs.get("model_type", NOSTR)
     mosbasic["visit"] = kwargs.get("visit", NONUM)
     mosbasic["segment"] = kwargs.get("segment", NONUM)
     mosbasic["pass_number"] = kwargs.get("pass_number", NONUM)

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -112,10 +112,7 @@ def test_datamodel_maker(model_class):
     model.validate()
 
     if issubclass(model_class, _RomanDataModel):
-        if isinstance(model, datamodels.MosaicModel):
-            assert model.meta.basic.model_type == model_class.__name__
-        else:
-            assert model.meta.model_type == model_class.__name__
+        assert model.meta.model_type == model_class.__name__
 
 
 @pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -707,7 +707,6 @@ def test_append_individual_image_meta_level3_mosaic():
     assert wfi_mosaic_model.meta.individual_image_meta.program["pi_name"][2] == "Roman"
 
 
-
 def test_datamodel_info_search(capsys):
     wfi_science_raw = utils.mk_level1_science_raw(shape=(2, 8, 8))
     af = asdf.AsdfFile()

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -339,7 +339,6 @@ def test_node_representation(model):
                     "time_mean_mjd": -999999,
                     "max_exposure_time": -999999,
                     "mean_exposure_time": -999999,
-                    "model_type": "MosaicModel",
                     "visit": -999999,
                     "segment": -999999,
                     "pass_number": -999999,


### PR DESCRIPTION
WIP [RCAL-704](https://jira.stsci.edu/browse/RCAL-704)

Issues resolved to get the resample step to execute.

- This resolves an issue with the default value of the `meta.wcsinfo.project` being assigned in the maker utilities.
- loss of `meta.filename`